### PR TITLE
26 feat (data) fix error parsing yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ venv
 .pytest_cache
 .env
 .envrc
+.twitter_keys.yaml
 
 outputs
 models

--- a/src/data/make_dataset/macron.py
+++ b/src/data/make_dataset/macron.py
@@ -9,11 +9,12 @@ MAX_TWEET = 10
 SAVE_PATH = f"data/raw/twitter/{user}/"
 KEYS_YAML_PATH = f".twitter_keys.yaml"
 
+
 def make_dataset_macron():
     # Usage can be found here:
     #   https://github.com/twitterdev/search-tweets-python/blob/v2/searchtweets/credentials.py
     search_args = load_credentials(filename=KEYS_YAML_PATH,
-    yaml_key="search_tweets_v2_recent", env_overwrite=False)
+                                   yaml_key="search_tweets_v2_recent", env_overwrite=False)
     query = gen_request_parameters(
         "Emmanuel Macron", results_per_call=MAX_TWEET, granularity=None)
     print(query)

--- a/src/data/make_dataset/macron.py
+++ b/src/data/make_dataset/macron.py
@@ -7,14 +7,13 @@ import os
 user = "macron"
 MAX_TWEET = 10
 SAVE_PATH = f"data/raw/twitter/{user}/"
-KEYS_PATH_YAM = f".twitter_keys.yaml"
-
+KEYS_YAML_PATH = f".twitter_keys.yaml"
 
 def make_dataset_macron():
     # Usage can be found here:
     #   https://github.com/twitterdev/search-tweets-python/blob/v2/searchtweets/credentials.py
-    search_args = load_credentials(filename=KEYS_PATH_YAM,
-    yaml_key="search_tweet_v2_recent", env_overwrite=False)
+    search_args = load_credentials(filename=KEYS_YAML_PATH,
+    yaml_key="search_tweets_v2_recent", env_overwrite=False)
     query = gen_request_parameters(
         "Emmanuel Macron", results_per_call=MAX_TWEET, granularity=None)
     print(query)

--- a/src/data/make_dataset/macron.py
+++ b/src/data/make_dataset/macron.py
@@ -5,16 +5,18 @@ import pandas as pd
 import os
 
 user = "macron"
-MAX_TWEET = 100
+MAX_TWEET = 10
 SAVE_PATH = f"data/raw/twitter/{user}/"
+KEYS_PATH_YAM = f".twitter_keys.yaml"
 
 
 def make_dataset_macron():
     # Usage can be found here:
-    #   https://github.com/twitterdev/search-tweets-python/blob/46386e0316b79096b5c5369abbc4f361b8153622/searchtweets/credentials.py#L114
-    search_args = load_credentials(env_overwrite=False)
+    #   https://github.com/twitterdev/search-tweets-python/blob/v2/searchtweets/credentials.py
+    search_args = load_credentials(filename=KEYS_PATH_YAM,
+    yaml_key="search_tweet_v2_recent", env_overwrite=False)
     query = gen_request_parameters(
-        "Emmanuel Macron", results_per_call=100, granularity=None)
+        "Emmanuel Macron", results_per_call=MAX_TWEET, granularity=None)
     print(query)
     tweets = collect_results(query, max_tweets=MAX_TWEET,
                              result_stream_args=search_args)


### PR DESCRIPTION
# Description

Small Modifications of the python script that requests macron tweets to the twitter API, it now searchs for a key in a YAML file.
This file is added to the `.gitignore`.
It is now possible to call another key in this YAML file in order to search a different endpoint or use different credentials.
It also removes the error about not finding a YAML file.

Fixes: issue #26 

## Type of change

Please delete options that are not relevant.

- [ ] Preliminary work 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] No error when executing `python -m src data --download macron`

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules