### PR TITLE
script fixed and tweets for 04-04 downloaded

### DIFF
--- a/.42AI/get_dataset_script1.sh
+++ b/.42AI/get_dataset_script1.sh
@@ -23,7 +23,7 @@ for candidat in "${CANDIDATS[@]}"; do
     sleep 60
 done
 
-# poetry run dvc add data.dvc
+# poetry run dvc add data
 # poetry run dvc push
 # git add data.dvc
 # git commit -m $1

--- a/.42AI/get_dataset_script1.sh
+++ b/.42AI/get_dataset_script1.sh
@@ -7,9 +7,9 @@ COLOR_RESET="\e[0m"
 
 # request forging Twitter API related variables
 CANDIDATS=("Pecresse" "Zemmour" "Dupont-Aignan" "Melenchon" "Le Pen" "Lassalle" "Hidalgo" "Macron" "Jadot" "Roussel" "Arthaud" "Poutou")
-DD="23"
-DATE_STARTS=("2022-03-$DD 8:00" "2022-03-$DD 12:00" "2022-03-$DD 16:00" "2022-03-$DD 20:00")
-DATE_ENDS=("2022-03-$DD 12:00" "2022-03-$DD 16:00" "2022-03-$DD 20:00" "2022-03-$DD 23:59")
+DD="04-04"
+DATE_STARTS=("2022-$DD 0:00" "2022-$DD 4:00" "2022-$DD 8:00" "2022-$DD 12:00" "2022-$DD 16:00" "2022-$DD 20:00")
+DATE_ENDS=("2022-$DD 4:00" "2022-$DD 8:00" "2022-$DD 12:00" "2022-$DD 16:00" "2022-$DD 20:00" "2022-$DD 23:59")
 
 
 # Print array values in  lines
@@ -17,10 +17,10 @@ echo "Print every element in new line"
 for candidat in "${CANDIDATS[@]}"; do
     for i in "${!DATE_STARTS[@]}"; do
         echo -e $COLOR_CYAN "downloading..." "$candidat" "${DATE_STARTS[i]}" "${DATE_ENDS[i]}" $COLOR_RESET
-        poetry run python -m src data --download twitter --mention "$candidat" --start_time "${DATE_STARTS[i]}" --end_time "${DATE_ENDS[i]}"
+        poetry run python -m src data --task download --data twitter --candidate "$candidat" --start_time "${DATE_STARTS[i]}" --end_time "${DATE_ENDS[i]}"
     done
-    echo -e $COLOR_PURPLE "... sleeping 30 seconds to avoid limit rate ..." $COLOR_RESET
-    sleep 30
+    echo -e $COLOR_PURPLE "... sleeping 60 seconds to avoid limit rate ..." $COLOR_RESET
+    sleep 60
 done
 
 # poetry run dvc add data.dvc

--- a/data.dvc
+++ b/data.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ff7b56ee536ae07bbe205f1cbc9db8a6.dir
-  size: 236895145
-  nfiles: 1780
+- md5: 1fe9dbcfdac00f9bae4ebb493037fb69.dir
+  size: 248547510
+  nfiles: 1904
   path: data

--- a/src/data/download/download_tweets.py
+++ b/src/data/download/download_tweets.py
@@ -58,8 +58,8 @@ TAGS = {"Pecresse": "@avecValerie",
 CREDENTIAL_FILE = ".twitter_keys.yaml"
 # maybe later we would be able to use all, then we could change with search_tweets_v2_all
 TWITTER_KEY = 'search_tweets_v2_recent'
-NB_MAX_TWEETS = 50  # Max number of tweets one wants
-RES_PER_CALL = 10  # Max number of tweets per query to Twitter API
+NB_MAX_TWEETS = 1000  # Max number of tweets one wants
+RES_PER_CALL = 100  # Max number of tweets per query to Twitter API
 SAVE_PATH = os.path.join("data", "raw", "twitter")
 
 # ########################################################################### #
@@ -211,7 +211,7 @@ def make_dataset_twitter(txt: str, mention: str, start_time: str, end_time: str,
     s_query = mention
     if txt is not None:
         s_query += ' ' + txt
-    s_query += ' ' + "-has:media"
+    s_query += ' ' + "-has:media -is:retweet"
     query = gen_request_parameters(s_query,
                                    results_per_call=RES_PER_CALL,
                                    granularity=None,

--- a/src/data/main.py
+++ b/src/data/main.py
@@ -1,8 +1,6 @@
 import argparse
 from email.policy import default
 
-from src.data.make_dataset.aclImdb import make_dataset_aclImdb
-from src.data.make_dataset.allocine import make_dataset_allocine
 from src.data.download.download_tweets import download_tweets
 from src.data.make_dataset.make_dataset_twitter import make_dataset_twitter
 from src.data.make_dataset.make_dataset_allocine import make_dataset_allocine


### PR DESCRIPTION
Script `.42AI/get_dataset_script1.sh` updated with recent changes of CLI.
Max number of tweet raised to 1000 per session, and added sessions for 00 to 04 AM and 04 to 08 AM in the script.
Tweets downloaded and saved in the remote s3 for 04-04.
New `data.dvc` pushed to git.